### PR TITLE
chore: rename uws to core

### DIFF
--- a/lib/relaybox.ts
+++ b/lib/relaybox.ts
@@ -6,7 +6,7 @@ import { PublishResponseData, TokenResponse, TokenResponseParams } from './types
 import { ApiKeyParts, RelayBoxOptions } from './types/config.types';
 import { validatePermissions, validateParams } from './validation';
 
-const DEFAULT_UWS_SERVICE_URL = `https://gnet.prod.relaybox-services.net`;
+const DEFAULT_CORE_SERVICE_URL = `https://gnet.prod.relaybox-services.net`;
 const DEFAULT_TOKEN_EXPIRY_SECS = 900;
 const DEFAULT_TOKEN_TYPE = 'id_token';
 
@@ -16,17 +16,17 @@ const DEFAULT_TOKEN_TYPE = 'id_token';
  */
 export class RelayBox {
   private apiKeyParts: ApiKeyParts;
-  private uwsServiceUrl: string;
+  private coreServiceUrl: string;
 
   /**
    * Creates an instance of RelayBox.
    * @param {RelayBoxOptions} options - The options for configuring the RelayBox instance.
    * @throws {ValidationError} If the API key is not provided or is invalid.
    */
-  constructor({ apiKey, uwsServiceUrl }: RelayBoxOptions) {
+  constructor({ apiKey, coreServiceUrl }: RelayBoxOptions) {
     validateParams({ apiKey }, ['apiKey']);
     this.apiKeyParts = this.getApiKeyParts(apiKey);
-    this.uwsServiceUrl = uwsServiceUrl || DEFAULT_UWS_SERVICE_URL;
+    this.coreServiceUrl = coreServiceUrl || DEFAULT_CORE_SERVICE_URL;
   }
 
   /**
@@ -90,7 +90,7 @@ export class RelayBox {
     };
 
     const response = await request<PublishResponseData>(
-      `${this.uwsServiceUrl}/events`,
+      `${this.coreServiceUrl}/events`,
       requestParams
     );
 

--- a/lib/types/config.types.ts
+++ b/lib/types/config.types.ts
@@ -1,6 +1,6 @@
 export interface RelayBoxOptions {
   apiKey: string;
-  uwsServiceUrl?: string;
+  coreServiceUrl?: string;
 }
 
 export interface ApiKeyParts {

--- a/test/relaybox.test.ts
+++ b/test/relaybox.test.ts
@@ -8,7 +8,7 @@ import { generateHmacSignature } from '../lib/signature';
 import { HTTPRequestError } from '../lib/errors';
 
 const server = setupServer();
-const mockUwsServiceUrl = `http://localhost:9090/uws`;
+const mockCoreServiceUrl = `http://localhost:9090/core`;
 const mockSecretKey = `abcde`;
 const mockApiKey = `appPid.keyId:${mockSecretKey}`;
 const mockclientId = `12345`;
@@ -36,7 +36,7 @@ describe('Ds', () => {
   beforeEach(() => {
     relayBox = new RelayBox({
       apiKey: mockApiKey,
-      uwsServiceUrl: mockUwsServiceUrl
+      coreServiceUrl: mockCoreServiceUrl
     });
   });
 
@@ -129,7 +129,7 @@ describe('Ds', () => {
         );
 
         server.use(
-          http.post(`${mockUwsServiceUrl}/events`, ({ request }) => {
+          http.post(`${mockCoreServiceUrl}/events`, ({ request }) => {
             const publicKey = request.headers.get('x-ds-public-key');
             const signature = request.headers.get('x-ds-req-signature');
 
@@ -165,7 +165,7 @@ describe('Ds', () => {
         vi.advanceTimersByTime(1);
 
         server.use(
-          http.post(`${mockUwsServiceUrl}/events`, ({ request }) => {
+          http.post(`${mockCoreServiceUrl}/events`, ({ request }) => {
             const signature = request.headers.get('x-ds-req-signature');
 
             if (signature !== mockSignature) {


### PR DESCRIPTION
Replace `uws` with `core` to align with core repo renaming