### PR TITLE
chore: use default export for relaybox class

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,5 @@
-export * from './relaybox';
 export * from './types';
+
+import RelayBox from './relaybox';
+
+export default RelayBox;

--- a/lib/relaybox.ts
+++ b/lib/relaybox.ts
@@ -14,7 +14,7 @@ const DEFAULT_TOKEN_TYPE = 'id_token';
  * The RelayBox class provides methods to generate authentication tokens and publish events
  * to a specified service using an API key.
  */
-export class RelayBox {
+export default class RelayBox {
   private apiKeyParts: ApiKeyParts;
   private coreServiceUrl: string;
 

--- a/test/relaybox.test.ts
+++ b/test/relaybox.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, afterEach, beforeAll, afterAll, beforeEach } from 'vitest';
 import { setupServer } from 'msw/node';
 import { HttpResponse, http } from 'msw';
-import { RelayBox } from '../lib/relaybox';
+import RelayBox from '../lib/relaybox';
 import jwt from 'jsonwebtoken';
 import { ExtendedJwtPayload } from '../lib/types/jwt.types';
 import { generateHmacSignature } from '../lib/signature';


### PR DESCRIPTION
- Adds default `RelayBox` export 
- Replaces named export entrypoint